### PR TITLE
Change api to cdn

### DIFF
--- a/lib/contentful/delivery.ex
+++ b/lib/contentful/delivery.ex
@@ -8,7 +8,7 @@ defmodule Contentful.Delivery do
   require Logger
   use HTTPoison.Base
 
-  @endpoint "api.contentful.com"
+  @endpoint "cdn.contentful.com"
   @protocol "https"
 
   def space(space_id, access_token) do


### PR DESCRIPTION
PD#1967

FAQ Service down.

Contentful documentation recommends to use CDN over api. This would resolve the PD incident #1967